### PR TITLE
Add pre-commit.ci integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: check-case-conflict
+  - id: check-illegal-windows-names
+  - id: check-symlinks


### PR DESCRIPTION
This is primarily used to avoid issues with filenames where they are legal on *nix but not on Windows.